### PR TITLE
Prevent duplicate Jira tickets

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ const execute = promisify(exec);
 
   if (!match) return;
 
-  const issueNumber = match[0];
-  const newMsg = `[${issueNumber}] ${msg}`;
+  const issueTag = `[${match[0]}]`;
+  const newMsg = msg.startsWith(issueTag) ? msg : `${issueTag} ${msg}`;
 
   await write(msgFile, newMsg);
 })().catch((e) => {


### PR DESCRIPTION
Fixes #2.

This will check to see if a Jira ticket tag has already been added to the beginning of the commit message and if so just return the original commit message without adding another tag.

So if your original commit message was:
```sh
[AA-123] Commit message
```
You'll get this when you `git commit --amend`:
```sh
[AA-123] Commit message
```
Instead of:
```sh
[AA-123] [AA-123] Commit message
```