### PR TITLE
Support for Husky v7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ $ yarn add --dev prepare-branch-commit
 
 prepare-branch-commit is meant to be run as a Husky hook:
 
+**From Husky v7+**
+```bash
+npx husky add .husky/prepare-commit-msg 'npx --no-install prepare-branch-commit "$(echo $)1"'
+```
+
+**Husky v4 and below**
 ```json
 {
   // ...

--- a/index.js
+++ b/index.js
@@ -34,8 +34,10 @@ if (require.main === module) {
   const write = promisify(fs.writeFile);
   const execute = promisify(exec);
   (async () => {
-    if (process.env.HUSKY_GIT_PARAMS) {
-      const [msgFile] = process.env.HUSKY_GIT_PARAMS.split(' ');
+    const [msgFile] = process.env.HUSKY_GIT_PARAMS
+      ? process.env.HUSKY_GIT_PARAMS.split(' ')
+      : process.argv.slice(2);
+    if (msgFile) {
       const msg = (await read(msgFile)).toString();
 
       const out = await execute('git branch');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prepare-branch-commit",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": false,
   "description": "Add text to commits based on Jira ticket numbers in the branch name.",
   "repository": "https://github.com/Renddslow/prepare-branch-commit",


### PR DESCRIPTION
HUSKY_GIT_PARAMS was removed at some point between v4 and v7 and they don't make it particularly easy to see when exactly.